### PR TITLE
Remove libgcc dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - cloog 0.18.0 10  # [unix]
     - m2w64-toolchain  # [win]
   run:
-    - libgcc  # [unix]
     - libgfortran  # [not win]
     - m2w64-gcc-libs  # [win]
 


### PR DESCRIPTION
At the time libgcc provided fortran libs
Fixes #4