### PR TITLE
fix(build.sh): Remove install_name_tool from changing library names

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -60,7 +60,6 @@ make install
 if [[ "${target_platform}" == osx-* ]]; then
     for lib in blas cblas lapack lapacke; do
         mv $PREFIX/lib/lib$lib.dylib $PREFIX/lib/lib$lib.$PKG_VERSION.dylib
-        install_name_tool -id $PREFIX/lib/lib$lib.3.dylib $PREFIX/lib/lib$lib.$PKG_VERSION.dylib
         ln -s  $PREFIX/lib/lib$lib.$PKG_VERSION.dylib $PREFIX/lib/lib$lib.dylib
         ln -s  $PREFIX/lib/lib$lib.$PKG_VERSION.dylib $PREFIX/lib/lib$lib.3.dylib
     done


### PR DESCRIPTION
abscli was not able to test the numpy backage because of file not found errors while trying to locate the shared libraries (e.g. libcblas.3.dylib). Remove the line per Eric's suggestion resolved the issue.

Jira: CR-54