### PR TITLE
weigh down netlib with an extra feature (dev)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.12.0" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 {% set version_major = version.split(".")[0] %}
 # blas_major denotes major infrastructural change to how blas is managed
 {% set blas_major = "2" %}
@@ -49,7 +49,10 @@ outputs:
     build:
       string: {{ build_num }}_h{{ PKG_HASH }}_netlib
       track_features:
+        # netlib variants must have at least 1 more feature
+        # than all variants of non-netlib blas implementations
         - blas_netlib
+        - blas_netlib_2
       run_exports:
         - {{ pin_subpackage("libblas", max_pin="x") }}
     requirements:
@@ -82,6 +85,7 @@ outputs:
       string: {{ build_num }}_h{{ PKG_HASH }}_netlib
       track_features:
         - blas_netlib
+        - blas_netlib_2
       run_exports:
         - {{ pin_subpackage("libtmglib", max_pin="x") }}
     requirements:
@@ -112,6 +116,7 @@ outputs:
       string: {{ build_num }}_h{{ PKG_HASH }}_netlib
       track_features:
         - blas_netlib
+        - blas_netlib_2
       run_exports:
         - {{ pin_subpackage("libcblas", max_pin="x") }}
     requirements:
@@ -146,6 +151,7 @@ outputs:
       string: {{ build_num }}_h{{ PKG_HASH }}_netlib
       track_features:
         - blas_netlib
+        - blas_netlib_2
       run_exports:
         - {{ pin_subpackage("liblapack", max_pin="x") }}
     requirements:
@@ -179,6 +185,7 @@ outputs:
       string: {{ build_num }}_h{{ PKG_HASH }}_netlib
       track_features:
         - blas_netlib
+        - blas_netlib_2
       run_exports:
         - {{ pin_subpackage("liblapacke", max_pin="x") }}
     requirements:
@@ -215,6 +222,7 @@ outputs:
       string: {{ build_num }}_netlib
       track_features:
         - blas_netlib
+        - blas_netlib_2
     requirements:
       run:
         - {{ pin_subpackage("libblas", exact=True) }}
@@ -232,6 +240,7 @@ outputs:
       string: netlib
       track_features:
         - blas_netlib
+        - blas_netlib_2
     requirements:
       - {{ pin_subpackage("liblapack", exact=True) }}
       - {{ pin_subpackage("liblapacke", exact=True) }}


### PR DESCRIPTION
in terms of deprioritization weight, netlib should be weighed down by at least one more feature than all variants of other blas/lapack implementations

applies #71 to dev
