### PR TITLE
give lapack output a build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -263,7 +263,7 @@ outputs:
   # For compatiblity (see #33)
   - name: lapack
     build:
-      string: netlib
+      string: {{ build_num }}_netlib
     requirements:
       run:
         - liblapack {{ version }}


### PR DESCRIPTION
In https://github.com/conda-forge/lapack-feedstock/pull/67 we discussed outputs that coincide due to not having package hash in the build string. As it turns out `lapack` doesn't even have a build number, so does not get republished. Fix this.