### PR TITLE
Disable building INDEX64_EXT_API for better compatibility

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -12,6 +12,10 @@ for %%f in (CBLAS\testing\*.c) do (
 mkdir build
 cd build
 
+:: Disable building INDEX64_EXT_API, as it includes ILP64 symbols within the LP64 library.
+:: We cannot do that unless all the alternative providers do that as well, as otherwise
+:: packages can start linking to these symbols.
+
 cmake -G "Ninja" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DBUILD_SHARED_LIBS=yes ^
@@ -21,6 +25,7 @@ cmake -G "Ninja" ^
     -DLAPACKE=ON ^
     -DCBLAS=ON ^
     -DBUILD_DEPRECATED=ON ^
+    -DBUILD_INDEX64_EXT_API=OFF ^
     -Wno-dev ..
 
 ninja -j%CPU_COUNT%

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,6 +25,10 @@ export FFLAGS="$FFLAGS -fno-optimize-sibling-calls"
 
 # CMAKE_INSTALL_LIBDIR="lib" suppresses CentOS default of lib64 (conda expects lib)
 
+# Disable building INDEX64_EXT_API, as it includes ILP64 symbols within the LP64 library.
+# We cannot do that unless all the alternative providers do that as well, as otherwise
+# packages can start linking to these symbols.
+
 cmake \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_INSTALL_LIBDIR="lib" \
@@ -34,6 +38,7 @@ cmake \
   -DCBLAS=ON \
   -DBUILD_DEPRECATED=ON \
   -DTEST_FORTRAN_COMPILER=OFF \
+  -DBUILD_INDEX64_EXT_API=OFF \
   ${CMAKE_ARGS} ..
 
 make install -j${CPU_COUNT} VERBOSE=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "3.12.1" %}
 # if build_num is reset to 0 (for new version), update increment for blas_minor below
-{% set build_num = 1 %}
+{% set build_num = 2 %}
 {% set version_major = version.split(".")[0] %}
 {% set version_minor = version.split(".")[1] %}
 # blas_major denotes major infrastructural change to how blas is managed


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Disable building INDEX64_EXT_API, as it includes ILP64 symbols within the LP64 library.  We cannot do that unless all the alternative providers do that as well, as otherwise packages can start linking to these symbols.  We already hit this in the wild while trying to test BLIS with LAPACK 3.12.1.  See:
https://github.com/conda-forge/blas-feedstock/pull/152#issuecomment-3613845148

